### PR TITLE
V1.4.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@outburn/structure-navigator",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@outburn/structure-navigator",
-      "version": "1.4.2",
+      "version": "1.4.3",
       "license": "Apache-2.0",
       "dependencies": {
         "fhir-package-explorer": "^1.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@outburn/structure-navigator",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "Navigate and resolve FHIR element definitions using FSH-like paths",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -148,6 +148,10 @@ export class FhirStructureNavigator {
             const base = lastSegment.slice(0, -3);
             el.__name = el.type.map(t => `${base}${initCap(t.code!)}`);
           }
+        } else {
+          // Handle elements without types (e.g., contentReference elements)
+          const lastSegment = el.path.split('.').pop()!;
+          el.__name = [lastSegment];
         }
       }
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -274,6 +274,24 @@ describe('ElementFetcher', () => {
     expect(el.type?.[0].__kind).toBeDefined();
   });
 
+  it('resolves an element with contentReference and ensures __name is set (Bundle.entry.link)', async () => {
+    const el = await fetcher.getElement('Bundle', 'entry.link');
+    // Bundle.entry.link has contentReference="#Bundle.link"
+    expect(el.contentReference).toBe('#Bundle.link');
+    expect(el.__fromDefinition).toContain('StructureDefinition/Bundle');
+    expect(el.__name).toEqual(['link']);
+    expect(el.__name).toBeDefined();
+  });
+
+  it('resolves an element with recursive contentReference and ensures __name is set (Questionnaire.item.item.item)', async () => {
+    const el = await fetcher.getElement('Questionnaire', 'item.item.item');
+    // Questionnaire.item has contentReference="#Questionnaire.item", so deep nesting should resolve properly
+    expect(el.contentReference).toBe('#Questionnaire.item');
+    expect(el.__fromDefinition).toContain('StructureDefinition/Questionnaire');
+    expect(el.__name).toEqual(['item']);
+    expect(el.__name).toBeDefined();
+  });
+
   it('resolves an element through contentReference (Bundle.entry.link.url)', async () => {
     const el = await fetcher.getElement('Bundle', 'entry.link.url');
     // Bundle.entry.link has contentReference="#Bundle.link", so this should resolve to Bundle.link.url


### PR DESCRIPTION
fix: set __name property for elements with contentReference

Elements with contentReference (like Bundle.entry.link) were missing
the __name property because they don't have a type array. Added fallback
logic to compute __name from path segment for typeless elements.

Fixes navigation issues in contentReference traversal.